### PR TITLE
Earth vs Moon rotation rate tweak

### DIFF
--- a/Assets/Scenes/Views/EarthView.unity
+++ b/Assets/Scenes/Views/EarthView.unity
@@ -176,6 +176,10 @@ Prefab:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 11462598, guid: a5594a1a2c6c29647a9124ea0abfb953, type: 2}
+      propertyPath: speed
+      value: -10
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 8236412, guid: a5594a1a2c6c29647a9124ea0abfb953, type: 2}
     - {fileID: 6453998, guid: a5594a1a2c6c29647a9124ea0abfb953, type: 2}
@@ -221,7 +225,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6bb4f31e4b806a3469cc9a17f127685a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  rotateSpeed: {x: 0, y: -10, z: 0}
+  rotateSpeed: {x: 0, y: -2.5, z: 0}
   RandomRotationSpeed: 0
   RandomRotationDirection: 0
   RotationSpeedMin: {x: 0, y: 0, z: 0}
@@ -283,6 +287,10 @@ Prefab:
     - target: {fileID: 192134, guid: 6da2c9510ec42844ba8b1ec2349ff83a, type: 2}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11459584, guid: 6da2c9510ec42844ba8b1ec2349ff83a, type: 2}
+      propertyPath: speed
+      value: -10
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 6455996, guid: 6da2c9510ec42844ba8b1ec2349ff83a, type: 2}


### PR DESCRIPTION
This change makes the moon orbit slightly more realistic. It now orbits once (speed=-2.5) for every 4 earth days (speed=-10).

Previously, the moon went around twice (speed=-10) for every earth day (speed=-5), which is the opposite of how it happens in real life (moon orbits once every 27 earth days).

The 4:1 ratio is a compromise. Slower moon orbits would make it less likely users would see the moon and faster earth rotations would make it harder to look carefully at the beautifully rendered earth, and might start impacting the smoothness of the animation.

With the current moon speed, a passive viewer would see the initial animation, which zooms up to the earth with the moon swooping by in front, then as the narration is finishing, they see it enter the field of view again as it passess behind the earth.

PS - If you like the change, you can thank my son Karl, who spotted this "problem" when I first showed it to him.